### PR TITLE
Add custom color palette support

### DIFF
--- a/taterm.vala
+++ b/taterm.vala
@@ -21,7 +21,7 @@ using Gtk;
 using Vte;
 using Pango;
 
-static const string FONT = "11";
+static const string FONT = "Droid Sans Mono 10";
 static const string[] COLORS = {
 	"#000000", "#e5393d", "#64dd4a", "#ff9700",
 	"#0098dc", "#c64ae1", "#d5d7ff", "#ffffff",
@@ -161,8 +161,7 @@ class Taterm : Gtk.Application
 			set_cursor_blink_mode(Vte.TerminalCursorBlinkMode.OFF);
 			scrollback_lines = -1; /* infinity */
 			pointer_autohide = true;
-			/*font_desc = Pango.FontDescription.from_string("11");*/
-			font_desc = font;
+			set_font(font);
 			set_colors(fg_color, bg_color, palette);
 
 


### PR DESCRIPTION
I've added a simple hard-coded color palette setting.

I also fixed the font setting which was not working for me (I could not set anything but the font size).

I'm switching from evilvte to taterm, it had everything I need, no more (well, except that color palette thing :smile:)

Cheers
